### PR TITLE
Fix for #48 - calculate the minimum SIM index and use that as the offset. If SIMs labels are not indices (ints) then don't use the offset.

### DIFF
--- a/app/src/main/kotlin/com/goodwy/dialer/helpers/RecentsHelper.kt
+++ b/app/src/main/kotlin/com/goodwy/dialer/helpers/RecentsHelper.kt
@@ -152,8 +152,12 @@ class RecentsHelper(private val context: Context) {
         context.getAvailableSIMCardLabels().forEach {
             accountIdToSimIDMap[it.handle.id] = it.id
         }
-        val manufacturer = Build.MANUFACTURER.lowercase(Locale.getDefault())
-        val isHuawei = manufacturer.contains(Regex(pattern = "huawei|honor"))
+        val simOffset : Int? =  try {
+            1 - (accountIdToSimIDMap.keys.map { it.toInt() }.min())
+        }
+        catch (e: Exception ){
+            null
+        }
 
         val cursor = if (isNougatPlus()) {
             // https://issuetracker.google.com/issues/175198972?pli=1#comment6
@@ -269,15 +273,14 @@ class RecentsHelper(private val context: Context) {
                 // https://stackoverflow.com/questions/63834168/identifying-a-sim-card-slot-with-phone-account-id-in-android-calllogcalls
                 // On some devices PHONE_ACCOUNT_ID just returns the SIM card slot index
                 var simID = -1
-                if (accountId != null) {
+                if (simOffset != null && accountId != null) {
                     if (accountId.length == 1) {
                         accountId.toIntOrNull()?.let {
-                            val index = if (isHuawei) 1 else 0 //Huawei's sim card index returns (0,1...)
-                            simID = if (it >= 0) it + index else -1
+                            simID = if (it >= 0) it + simOffset else -1
                         }
                     }
                 }
-                if (simID == -1) simID = accountIdToSimIDMap[accountId] ?: -1
+                if (simID < 0) simID = accountIdToSimIDMap.getOrDefault(accountId, -1)
 
                 var specificNumber = ""
                 var specificType = ""


### PR DESCRIPTION
 Manufacturer | Minimum SIM slot |  offset |
| --- | --- | --- |
| Realme | "2" | -1 |
| Huawei | "0" | 1 | 
| Honor | "0" | 1 |
| Xiaomi | "1"  | 0 |
| Xiaomi | "random letters" | null |
| others | non numbers | null |