### PR TITLE
Improve T9 contact search for Arabic and other non-Latin names

### DIFF
--- a/app/src/main/kotlin/com/goodwy/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/goodwy/dialer/activities/DialpadActivity.kt
@@ -1187,13 +1187,13 @@ class DialpadActivity : SimpleActivity() {
                 || (convertedCompany.contains(text, true))
                 || (convertedCompanyDigitsOnly.contains(text, true))
         }.sortedWith(
-            compareByDescending<Contact> {
+            compareByDescending<Contact> { contact ->
+                contact.phoneNumbers.maxOfOrNull { callCounts[it.value.normalizePhoneNumber()] ?: 0 } ?: 0
+            }.thenByDescending {
                 DialpadT9.convertLettersToNumbers(
                     it.getNameToDisplay().normalizeString().uppercase(), lang)
                     .filter { c -> c.isDigit() }
                     .startsWith(text)
-            }.thenByDescending { contact ->
-                contact.phoneNumbers.maxOfOrNull { callCounts[it.value.normalizePhoneNumber()] ?: 0 } ?: 0
             }.thenBy(collator) { it.getNameToDisplay() }
         ).toMutableList() as ArrayList<Contact>
 

--- a/app/src/main/kotlin/com/goodwy/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/goodwy/dialer/activities/DialpadActivity.kt
@@ -1152,13 +1152,18 @@ class DialpadActivity : SimpleActivity() {
 
         val text = if (config.formatPhoneNumbers) textFormat.removeNumberFormatting() else textFormat
 
-        val collator = Collator.getInstance(sysLocale())
-        val filtered = allContacts.filter { contact ->
-            val langPref = config.dialpadSecondaryLanguage ?: ""
-            val langLocale = Locale.getDefault().language
-            val isAutoLang = DialpadT9.getSupportedSecondaryLanguages().contains(langLocale) && langPref == LANGUAGE_SYSTEM
-            val lang = if (isAutoLang) langLocale else langPref
+        val langPref = config.dialpadSecondaryLanguage ?: ""
+        val langLocale = Locale.getDefault().language
+        val isAutoLang = DialpadT9.getSupportedSecondaryLanguages().contains(langLocale) && langPref == LANGUAGE_SYSTEM
+        val lang = if (isAutoLang) langLocale else langPref
 
+        val collator = Collator.getInstance(sysLocale())
+        val callCounts = HashMap<String, Int>()
+        allRecentCalls.forEach { call ->
+            val key = call.phoneNumber.normalizePhoneNumber()
+            if (key.isNotEmpty()) callCounts[key] = (callCounts[key] ?: 0) + 1
+        }
+        val filtered = allContacts.filter { contact ->
             val convertedName = DialpadT9.convertLettersToNumbers(
                 contact.name.normalizeString().uppercase(), lang)
             val convertedNameWithoutSpaces = convertedName.filterNot { it.isWhitespace() }
@@ -1177,9 +1182,16 @@ class DialpadActivity : SimpleActivity() {
                 || (convertedNameToDisplayWithoutSpaces.contains(text, true))
                 || (convertedNickname.contains(text, true))
                 || (convertedCompany.contains(text, true))
-        }.sortedWith(compareBy(collator) {
-            it.getNameToDisplay()
-        }).toMutableList() as ArrayList<Contact>
+        }.sortedWith(
+            compareByDescending<Contact> {
+                DialpadT9.convertLettersToNumbers(
+                    it.getNameToDisplay().normalizeString().uppercase(), lang)
+                    .filterNot { c -> c.isWhitespace() }
+                    .startsWith(text)
+            }.thenByDescending { contact ->
+                contact.phoneNumbers.maxOfOrNull { callCounts[it.value.normalizePhoneNumber()] ?: 0 } ?: 0
+            }.thenBy(collator) { it.getNameToDisplay() }
+        ).toMutableList() as ArrayList<Contact>
 
 //        binding.letterFastscroller.setupWithContacts(binding.dialpadList, filtered)
 

--- a/app/src/main/kotlin/com/goodwy/dialer/activities/DialpadActivity.kt
+++ b/app/src/main/kotlin/com/goodwy/dialer/activities/DialpadActivity.kt
@@ -1166,27 +1166,31 @@ class DialpadActivity : SimpleActivity() {
         val filtered = allContacts.filter { contact ->
             val convertedName = DialpadT9.convertLettersToNumbers(
                 contact.name.normalizeString().uppercase(), lang)
-            val convertedNameWithoutSpaces = convertedName.filterNot { it.isWhitespace() }
+            val convertedNameDigitsOnly = convertedName.filter { it.isDigit() }
             val convertedNickname = DialpadT9.convertLettersToNumbers(
                 contact.nickname.normalizeString().uppercase(), lang)
+            val convertedNicknameDigitsOnly = convertedNickname.filter { it.isDigit() }
             val convertedCompany = DialpadT9.convertLettersToNumbers(
                 contact.organization.company.normalizeString().uppercase(), lang)
+            val convertedCompanyDigitsOnly = convertedCompany.filter { it.isDigit() }
             val convertedNameToDisplay = DialpadT9.convertLettersToNumbers(
                 contact.getNameToDisplay().normalizeString().uppercase(), lang)
-            val convertedNameToDisplayWithoutSpaces = convertedNameToDisplay.filterNot { it.isWhitespace() }
+            val convertedNameToDisplayDigitsOnly = convertedNameToDisplay.filter { it.isDigit() }
 
             contact.doesContainPhoneNumber(text, convertLetters = true, search = true)
                 || (convertedName.contains(text, true))
-                || (convertedNameWithoutSpaces.contains(text, true))
+                || (convertedNameDigitsOnly.contains(text, true))
                 || (convertedNameToDisplay.contains(text, true))
-                || (convertedNameToDisplayWithoutSpaces.contains(text, true))
+                || (convertedNameToDisplayDigitsOnly.contains(text, true))
                 || (convertedNickname.contains(text, true))
+                || (convertedNicknameDigitsOnly.contains(text, true))
                 || (convertedCompany.contains(text, true))
+                || (convertedCompanyDigitsOnly.contains(text, true))
         }.sortedWith(
             compareByDescending<Contact> {
                 DialpadT9.convertLettersToNumbers(
                     it.getNameToDisplay().normalizeString().uppercase(), lang)
-                    .filterNot { c -> c.isWhitespace() }
+                    .filter { c -> c.isDigit() }
                     .startsWith(text)
             }.thenByDescending { contact ->
                 contact.phoneNumbers.maxOfOrNull { callCounts[it.value.normalizePhoneNumber()] ?: 0 } ?: 0

--- a/app/src/main/kotlin/com/goodwy/dialer/adapters/ContactsAdapter.kt
+++ b/app/src/main/kotlin/com/goodwy/dialer/adapters/ContactsAdapter.kt
@@ -406,14 +406,21 @@ class ContactsAdapter(
     private fun String.highlightTextFromNumbers(textToHighlight: String, primaryColor: Int, language: String): SpannableString {
         val spannableString = SpannableString(this)
         val digits = DialpadT9.convertLettersToNumbers(this.uppercase(), language)
-        if (digits.contains(textToHighlight)) {
-            //offsetting the characters to be extracted, by the number of first non-letter or non-numeric characters.
-            val lettersAndNumbers = Regex("[^A-Za-z0-9 ]")
-            val firstSymbol = lettersAndNumbers.replace(this, "").firstOrNull()
-            val offsetIndex = if (firstSymbol != null) this.indexOf(firstSymbol, 0, true) else 0
 
-            val startIndex = digits.indexOf(textToHighlight, 0, true) + offsetIndex
-            val endIndex = (startIndex + textToHighlight.length).coerceAtMost(length)
+        val compressed = StringBuilder(digits.length)
+        val originalPos = IntArray(digits.length)
+        var written = 0
+        digits.forEachIndexed { i, c ->
+            if (!c.isWhitespace()) {
+                compressed.append(c)
+                originalPos[written++] = i
+            }
+        }
+        val start = compressed.indexOf(textToHighlight, 0, ignoreCase = true)
+        if (start >= 0) {
+            val startIndex = originalPos[start]
+            val endCompressed = (start + textToHighlight.length - 1).coerceAtMost(written - 1)
+            val endIndex = (originalPos[endCompressed] + 1).coerceAtMost(length)
             try {
                 spannableString.setSpan(ForegroundColorSpan(primaryColor), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_INCLUSIVE)
             } catch (_: IndexOutOfBoundsException) {

--- a/app/src/main/kotlin/com/goodwy/dialer/adapters/ContactsAdapter.kt
+++ b/app/src/main/kotlin/com/goodwy/dialer/adapters/ContactsAdapter.kt
@@ -411,7 +411,7 @@ class ContactsAdapter(
         val originalPos = IntArray(digits.length)
         var written = 0
         digits.forEachIndexed { i, c ->
-            if (!c.isWhitespace()) {
+            if (c.isDigit()) {
                 compressed.append(c)
                 originalPos[written++] = i
             }

--- a/app/src/main/kotlin/com/goodwy/dialer/adapters/ContactsAdapter.kt
+++ b/app/src/main/kotlin/com/goodwy/dialer/adapters/ContactsAdapter.kt
@@ -465,25 +465,11 @@ class ContactsAdapter(
                     if (normalizedName.contains(normalizedSearchText, true)) {
                         name.highlightTextPart(normalizedSearchText, properPrimaryColor)
                     } else {
-                        var spacedTextToHighlight = textToHighlight
-                        val strippedName = PhoneNumberUtils.convertKeypadLettersToDigits(name.filterNot { it.isWhitespace() })
-                        val startIndex = strippedName.indexOf(textToHighlight)
-
-                        if (strippedName.contains(textToHighlight) && strippedName != name) {
-                            for (i in 0..spacedTextToHighlight.length) {
-                                if (name.toCharArray().size > startIndex + i) {
-                                    if (name[startIndex + i].isWhitespace()) {
-                                        spacedTextToHighlight = spacedTextToHighlight.replaceRange(i, i, " ")
-                                    }
-                                }
-                            }
-                        }
-
                         val langPref = activity.config.dialpadSecondaryLanguage ?: ""
                         val langLocale = Locale.getDefault().language
                         val isAutoLang = DialpadT9.getSupportedSecondaryLanguages().contains(langLocale) && langPref == LANGUAGE_SYSTEM
                         val lang = if (isAutoLang) langLocale else langPref
-                        name.highlightTextFromNumbers(spacedTextToHighlight, properPrimaryColor, lang)
+                        name.highlightTextFromNumbers(textToHighlight, properPrimaryColor, lang)
                     }
                 }
             }


### PR DESCRIPTION
> ### **First of all, thanks to the maintainer and all the contributors who keep this project alive. I've contributed to this repo before, and I'm planning a few more improvements after this one. Really appreciate the work you all put in.**

## Summary

Four fixes to T9 contact search in the dialpad. Mostly about Arabic names, with a couple of side fixes for Latin names too.

## Fixes

1. **Wrong word highlighted in Arabic names.** Typing `8685` (which is `محمد` in T9) used to highlight a random nearby word like `بن`. An extra position offset was being added that only happened to be zero for English names starting with a letter, so the bug stayed hidden in Latin tests. Removed.

2. **Highlight stopped at spaces.** Typing `9878685` (which is `عمي محمد` across a space) listed the contact but colored nothing. Highlighter now compresses spaces out, finds the match, then maps positions back to the original string. As a side effect, this also fixes `(John) Smith` searched as `5646`.

3. **Some Arabic contacts disappeared from the results.** Any name with `أ`, `إ`, `آ`, `ؤ`, or `ئ` could be silently filtered out. `normalizeString` decomposes them into base letter plus a combining mark, and the strip regex only covers `U+0300`–`U+036F`. The Arabic combining marks live above that range, so they survived and broke the digit substring match. Filter now compares against a digits-only version of the converted name, which ignores combining marks (and parens and other noise) by construction. Nickname and the company also gained the digits-only check that they were missing.

4. **Sort order didn't reflect who you actually called.** Results were sorted alphabetically only. Sort now has three tiers:

   1. Most-called first (from the existing in-memory recents)
   2. Names that start with the typed digits, as a tiebreaker
   3. Alphabetical fallback

5. **Bonus fix found during testing.** Names that mix scripts, like `محمد Smith` (Arabic-script first name + Latin-script surname), didn't highlight the Latin part. Old preprocessing was injecting a literal space into the search query, which the new digit-only highlighter doesn't expect. Preprocessing removed highlighter handles cross-space matches itself now.

## Files changed

- `app/src/main/kotlin/com/goodwy/dialer/adapters/ContactsAdapter.kt`
- `app/src/main/kotlin/com/goodwy/dialer/activities/DialpadActivity.kt`

## Test plan
All the below test cases has been tested and it's passed 
- [x] Type `8685` → `محمد` highlighted on every row
- [x] Type `9878685` → `عمي محمد` highlighted across the space
- [x] Type `32749` → contacts with `أبو سعود` show up, heavily called ones near the top
- [x] Type `624` on an Arabic-first + Latin-surname contact → Latin part is highlighted
- [x] Type `5646` on `John Smith` → `John` highlighted (Latin regression check)
- [x] Type `5646` on `(John) Smith` → `John` highlighted (latent bug also fixed)

## Closes

- Closes #146 — *T9 search should prioritize most frequently used contacts* — handled by the new call-frequency sort tier
- Closes #140 — *Contact search should be diacritic-insensitive* — the digits-only filter is inherently diacritic-agnostic for T9 input
- Closes #108 — *sort type on search result not only alphabetical* — three-tier sort (frequency → starts-with → alphabetical)

## Notes

- Four commits are kept separate, so each fix is easy to follow. 
- "Most called" uses the recents window the dialer already keeps in memory (`queryLimitRecent`, default 1000). No extra storage or query.
- No new dependencies, no schema or settings changes.
- **Disclaimer:** I used Claude to help write and refactor the code, but I manually tested every scenario on my device before opening this PR.